### PR TITLE
Fix frontend lint issues

### DIFF
--- a/frontend/apps/web/src/components/Layout.tsx
+++ b/frontend/apps/web/src/components/Layout.tsx
@@ -307,9 +307,10 @@ export function Layout() {
   const ungroupedSubscriptions = subscriptionsByFolder['__ungrouped__'] || []
 
   // Close mobile sidebar on navigation
+  const searchParamsString = searchParams.toString()
   useEffect(() => {
     setIsMobileSidebarOpen(false)
-  }, [location.pathname, searchParams.toString()])
+  }, [location.pathname, searchParamsString])
 
   return (
     <div className="flex h-screen flex-col bg-background md:flex-row">


### PR DESCRIPTION
Extract searchParams.toString() to a variable to avoid complex expression in useEffect dependency array. This fixes the react-hooks/exhaustive-deps ESLint warning.