### PR TITLE
Fix TypeScript error in client electronAPI property

### DIFF
--- a/frontend/packages/api-client/src/client.ts
+++ b/frontend/packages/api-client/src/client.ts
@@ -191,7 +191,7 @@ export class ApiClient {
       // Validate URL before caching
       if (this.isValidUrl(url)) {
         this.cachedApiUrl = url
-        return this.cachedApiUrl
+        return url
       } else {
         console.error('Invalid API URL retrieved from Electron:', url)
         return ''

--- a/frontend/packages/api-client/src/types/electron.d.ts
+++ b/frontend/packages/api-client/src/types/electron.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Type declarations for Electron IPC API.
+ *
+ * These types define the electronAPI interface that's exposed
+ * via Electron's contextBridge in the preload script.
+ */
+
+interface ElectronAPI {
+  /**
+   * Get the configured API URL from Electron settings
+   */
+  getApiUrl(): Promise<string>
+
+  /**
+   * Get access token from secure storage
+   */
+  getAccessToken(): Promise<string | null>
+
+  /**
+   * Get refresh token from secure storage
+   */
+  getRefreshToken(): Promise<string | null>
+
+  /**
+   * Save access token to secure storage
+   */
+  setAccessToken(token: string | null): Promise<void>
+
+  /**
+   * Save refresh token to secure storage
+   */
+  setRefreshToken(token: string | null): Promise<void>
+
+  /**
+   * Clear all tokens from secure storage
+   */
+  clearTokens(): Promise<void>
+}
+
+declare global {
+  interface Window {
+    electronAPI?: ElectronAPI
+  }
+}
+
+export {}


### PR DESCRIPTION
- Add type definitions for window.electronAPI interface
- Create electron.d.ts with ElectronAPI interface declaration
- Fix type error in client.ts by returning url directly instead of cached value
- All typecheck errors in @glean/api-client package are now resolved