### PR TITLE
feat(reader): add keyboard navigation with settings toggle

### DIFF
--- a/frontend/apps/web/src/__tests__/stores/authStore.test.ts
+++ b/frontend/apps/web/src/__tests__/stores/authStore.test.ts
@@ -194,14 +194,24 @@ describe('authStore', () => {
   })
 
   describe('updateSettings', () => {
-    it('should update user settings', async () => {
-      const updatedUser = createMockUser({ ...mockUser, settings: { read_later_days: 7 } })
+    it('should merge and update user settings', async () => {
+      const userWithSettings = createMockUser({
+        ...mockUser,
+        settings: { show_read_later_remaining: true },
+      })
+      useAuthStore.setState({ user: userWithSettings })
+      const updatedUser = createMockUser({
+        ...userWithSettings,
+        settings: { show_read_later_remaining: true, read_later_days: 7 },
+      })
       vi.mocked(authService.updateUser).mockResolvedValue(updatedUser)
 
       await useAuthStore.getState().updateSettings({ read_later_days: 7 })
 
       expect(useAuthStore.getState().user).toEqual(updatedUser)
-      expect(authService.updateUser).toHaveBeenCalledWith({ settings: { read_later_days: 7 } })
+      expect(authService.updateUser).toHaveBeenCalledWith({
+        settings: { show_read_later_remaining: true, read_later_days: 7 },
+      })
     })
 
     it('should set error on failure', async () => {

--- a/frontend/apps/web/src/pages/ReaderPage.tsx
+++ b/frontend/apps/web/src/pages/ReaderPage.tsx
@@ -393,12 +393,21 @@ export default function ReaderPage() {
     (e: KeyboardEvent) => {
       if (!keyboardNavigationEnabled) return
 
-      // Ignore when focus is in input, textarea, or contenteditable elements
+      // Ignore when focus is in an input, textarea, contenteditable, or any
+      // interactive control that owns its own keyboard navigation (buttons,
+      // links, select elements, and Radix/ARIA widgets such as menus,
+      // listboxes, comboboxes, dialogs, and their items).
       const target = e.target as HTMLElement
       if (
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||
-        target.isContentEditable
+        target.tagName === 'BUTTON' ||
+        target.tagName === 'SELECT' ||
+        target.tagName === 'A' ||
+        target.isContentEditable ||
+        target.closest(
+          '[role="menu"],[role="menubar"],[role="listbox"],[role="combobox"],[role="dialog"],[role="alertdialog"],[role="tree"],[role="grid"],[role="tablist"]'
+        )
       ) {
         return
       }

--- a/frontend/apps/web/src/pages/ReaderPage.tsx
+++ b/frontend/apps/web/src/pages/ReaderPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import {
   useInfiniteEntries,
@@ -352,36 +352,98 @@ export default function ReaderPage() {
     }
   }, [selectedFeedId, selectedFolderId, isSmartView, entryIdFromUrl])
 
+  const keyboardNavigationEnabled = user?.settings?.keyboard_navigation ?? true
+
   // Handle entry selection - automatically mark as read
-  const handleSelectEntry = async (entry: EntryWithState) => {
-    // On mobile, trigger entry list exit animation while opening reader
-    if (isMobile) {
-      setIsExitingEntryList(true)
-      setSelectedEntryId(entry.id)
-      // Notify Layout to hide its header (ArticleReader will show its own)
-      window.dispatchEvent(new CustomEvent('showArticleReader'))
-    } else {
-      setSelectedEntryId(entry.id)
-    }
-
-    // Save the original position data when first selecting an entry
-    // This ensures the entry stays in place even after like/dislike/bookmark actions
-    if (selectedEntryOriginalDataRef.current?.id !== entry.id) {
-      selectedEntryOriginalDataRef.current = {
-        id: entry.id,
-        preferenceScore: entry.preference_score,
-        publishedAt: entry.published_at,
+  const handleSelectEntry = useCallback(
+    async (entry: EntryWithState) => {
+      // On mobile, trigger entry list exit animation while opening reader
+      if (isMobile) {
+        setIsExitingEntryList(true)
+        setSelectedEntryId(entry.id)
+        // Notify Layout to hide its header (ArticleReader will show its own)
+        window.dispatchEvent(new CustomEvent('showArticleReader'))
+      } else {
+        setSelectedEntryId(entry.id)
       }
-    }
 
-    // Auto-mark as read when selecting an unread entry
-    if (!entry.is_read) {
-      await updateMutation.mutateAsync({
-        entryId: entry.id,
-        data: { is_read: true },
-      })
-    }
-  }
+      // Save the original position data when first selecting an entry
+      // This ensures the entry stays in place even after like/dislike/bookmark actions
+      if (selectedEntryOriginalDataRef.current?.id !== entry.id) {
+        selectedEntryOriginalDataRef.current = {
+          id: entry.id,
+          preferenceScore: entry.preference_score,
+          publishedAt: entry.published_at,
+        }
+      }
+
+      // Auto-mark as read when selecting an unread entry
+      if (!entry.is_read) {
+        await updateMutation.mutateAsync({
+          entryId: entry.id,
+          data: { is_read: true },
+        })
+      }
+    },
+    [isMobile, updateMutation]
+  )
+
+  // Keyboard navigation: arrow keys and j/k to switch between entries
+  const handleKeyboardNavigation = useCallback(
+    (e: KeyboardEvent) => {
+      if (!keyboardNavigationEnabled) return
+
+      // Ignore when focus is in input, textarea, or contenteditable elements
+      const target = e.target as HTMLElement
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+
+      const isNext = e.key === 'ArrowDown' || e.key === 'j'
+      const isPrev = e.key === 'ArrowUp' || e.key === 'k'
+      if (!isNext && !isPrev) return
+
+      e.preventDefault()
+
+      if (entries.length === 0) return
+
+      const currentIndex = selectedEntryId
+        ? entries.findIndex((entry) => entry.id === selectedEntryId)
+        : -1
+
+      let nextIndex: number
+      if (currentIndex === -1) {
+        nextIndex = 0
+      } else if (isNext) {
+        if (currentIndex >= entries.length - 1) return
+        nextIndex = currentIndex + 1
+      } else {
+        if (currentIndex <= 0) return
+        nextIndex = currentIndex - 1
+      }
+
+      const nextEntry = entries[nextIndex]
+      if (nextEntry) {
+        handleSelectEntry(nextEntry)
+        const entryEl = entryListRef.current?.querySelector(
+          `[data-entry-id="${nextEntry.id}"]`
+        )
+        if (entryEl) {
+          entryEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+        }
+      }
+    },
+    [entries, selectedEntryId, keyboardNavigationEnabled, handleSelectEntry]
+  )
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyboardNavigation)
+    return () => document.removeEventListener('keydown', handleKeyboardNavigation)
+  }, [handleKeyboardNavigation])
 
   useEffect(() => {
     localStorage.setItem('glean:entriesWidth', String(entriesWidth))
@@ -591,6 +653,7 @@ export default function ReaderPage() {
                         (user?.settings?.show_read_later_remaining ?? true)
                       }
                       showPreferenceScore={usesSmartSorting && showPreferenceScore}
+                      dataEntryId={entry.id}
                     />
                   ))}
                 </div>
@@ -778,6 +841,7 @@ function EntryListItem({
   showFeedInfo = false,
   showReadLaterRemaining = false,
   showPreferenceScore = false,
+  dataEntryId,
 }: {
   entry: EntryWithState
   isSelected: boolean
@@ -786,11 +850,13 @@ function EntryListItem({
   showFeedInfo?: boolean
   showReadLaterRemaining?: boolean
   showPreferenceScore?: boolean
+  dataEntryId?: string
 }) {
   const remainingTime = showReadLaterRemaining ? formatRemainingTime(entry.read_later_until) : null
   return (
     <div
       onClick={onClick}
+      data-entry-id={dataEntryId}
       className={`group animate-fade-in cursor-pointer px-1.5 py-1.5 transition-all duration-200 ${
         isSelected
           ? 'before:bg-primary relative before:absolute before:inset-y-0.5 before:left-0 before:w-0.5 before:rounded-full'

--- a/frontend/apps/web/src/pages/SettingsPage.tsx
+++ b/frontend/apps/web/src/pages/SettingsPage.tsx
@@ -18,6 +18,7 @@ import {
   Sparkles,
   Languages,
   Key,
+  Keyboard,
 } from 'lucide-react'
 import {
   Label,
@@ -62,6 +63,7 @@ export default function SettingsPage() {
   // Get current read_later_days from user settings, default to 7
   const currentReadLaterDays = user?.settings?.read_later_days ?? 7
   const showReadLaterRemaining = user?.settings?.show_read_later_remaining ?? true
+  const keyboardNavigationEnabled = user?.settings?.keyboard_navigation ?? true
 
   const handleReadLaterDaysChange = async (days: number) => {
     setIsSaving(true)
@@ -82,6 +84,20 @@ export default function SettingsPage() {
     setSaveSuccess(false)
     try {
       await updateSettings({ show_read_later_remaining: !showReadLaterRemaining })
+      setSaveSuccess(true)
+      setTimeout(() => setSaveSuccess(false), 2000)
+    } catch {
+      // Error is handled by the store
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleToggleKeyboardNavigation = async () => {
+    setIsSaving(true)
+    setSaveSuccess(false)
+    try {
+      await updateSettings({ keyboard_navigation: !keyboardNavigationEnabled })
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 2000)
     } catch {
@@ -371,6 +387,39 @@ export default function SettingsPage() {
             ))}
           </div>
         </div>
+
+        <div
+          className="border-border/50 from-muted/30 to-muted/10 ring-border/20 animate-fade-in rounded-xl border bg-gradient-to-br p-5 ring-1"
+          style={{ animationDelay: '100ms' }}
+        >
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-1 items-center gap-3">
+              <div className="bg-primary/10 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg">
+                <Keyboard className="text-primary h-5 w-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <Label className="text-foreground block text-sm font-medium">
+                  {t('appearance.keyboardNavigation')}
+                </Label>
+                <p className="text-muted-foreground text-xs">
+                  {t('appearance.keyboardNavigationDesc')}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={keyboardNavigationEnabled}
+              onCheckedChange={handleToggleKeyboardNavigation}
+              disabled={isSaving || isLoading}
+            />
+          </div>
+        </div>
+
+        {saveSuccess && (
+          <div className="animate-fade-in flex items-center gap-2 rounded-lg bg-green-500/10 px-4 py-3 text-sm text-green-600 ring-1 ring-green-500/20">
+            <CheckCircle className="h-4 w-4" />
+            {t('appearance.settingsSaved')}
+          </div>
+        )}
       </div>
     )
   }

--- a/frontend/apps/web/src/stores/authStore.ts
+++ b/frontend/apps/web/src/stores/authStore.ts
@@ -118,7 +118,12 @@ export const useAuthStore = create<AuthState>((set) => ({
   updateSettings: async (settings) => {
     set({ isLoading: true, error: null })
     try {
-      const user = await authService.updateUser({ settings })
+      const currentUser = useAuthStore.getState().user
+      const mergedSettings = {
+        ...currentUser?.settings,
+        ...settings,
+      }
+      const user = await authService.updateUser({ settings: mergedSettings })
       set({
         user,
         isLoading: false,

--- a/frontend/packages/i18n/src/locales/en/settings.json
+++ b/frontend/packages/i18n/src/locales/en/settings.json
@@ -52,7 +52,10 @@
       "dayDesc": "Light theme for daytime use",
       "auto": "Auto",
       "autoDesc": "Follow your system preference"
-    }
+    },
+    "keyboardNavigation": "Keyboard Navigation",
+    "keyboardNavigationDesc": "Use arrow keys (↑/↓) or j/k to navigate between articles in the reader",
+    "settingsSaved": "Settings saved successfully"
   },
   "manageFeeds": {
     "title": "Manage Feeds",

--- a/frontend/packages/i18n/src/locales/zh-CN/settings.json
+++ b/frontend/packages/i18n/src/locales/zh-CN/settings.json
@@ -52,7 +52,10 @@
       "dayDesc": "浅色主题，适合日间使用",
       "auto": "自动",
       "autoDesc": "跟随系统偏好"
-    }
+    },
+    "keyboardNavigation": "键盘导航",
+    "keyboardNavigationDesc": "使用方向键（↑/↓）或 j/k 在阅读器中切换文章",
+    "settingsSaved": "设置已成功保存"
   },
   "manageFeeds": {
     "title": "管理订阅",

--- a/frontend/packages/types/src/models.ts
+++ b/frontend/packages/types/src/models.ts
@@ -9,6 +9,7 @@
 export interface UserSettings {
   read_later_days?: number // Days until read later items expire (0 = never)
   show_read_later_remaining?: boolean // Show remaining time in read later list
+  keyboard_navigation?: boolean // Use arrow keys / j/k to navigate between entries
 }
 
 /** User account information */


### PR DESCRIPTION
Enable arrow keys and j/k to move between entries in the reader, with an appearance setting to turn it off and merged user settings updates.

Originally purposed in #117 and credits to @GoToBoy.