### PR TITLE
fix(bookmark): truncate title to 500 chars when archiving

### DIFF
--- a/backend/packages/core/glean_core/services/bookmark_service.py
+++ b/backend/packages/core/glean_core/services/bookmark_service.py
@@ -224,7 +224,7 @@ class BookmarkService:
         Raises:
             ValueError: If entry not found or validation fails.
         """
-        title = data.title
+        title = data.title[:500] if data.title else data.title
         excerpt = data.excerpt
         entry_id = data.entry_id
         url = data.url


### PR DESCRIPTION
## Summary
- Fix `StringDataRightTruncationError` when archiving entries with long titles
- `Bookmark.title` is `VARCHAR(500)` but `Entry.title` allows up to 1000 chars
- Truncate title to 500 chars in `create_bookmark` to prevent the error

## Test
- Archive an entry with a title longer than 500 characters
- Verify the bookmark is created successfully with truncated title

Closes #125