### PR TITLE
fix(rss): buffer request body before forwarding in SSRFSafeTransport

### DIFF
--- a/backend/apps/api/tests/test_admin_api.py
+++ b/backend/apps/api/tests/test_admin_api.py
@@ -133,7 +133,7 @@ class TestAdminUsers:
     async def test_toggle_user_status_nonexistent(self, client: AsyncClient, admin_headers):
         """Test toggling status of nonexistent user."""
         response = await client.patch(
-            "/api/admin/users/nonexistent-id/status",
+            "/api/admin/users/00000000-0000-0000-0000-000000000000/status",
             headers=admin_headers,
             json={"is_active": False},
         )

--- a/backend/packages/rss/glean_rss/safe_http.py
+++ b/backend/packages/rss/glean_rss/safe_http.py
@@ -340,6 +340,10 @@ class SSRFSafeTransport(httpx.AsyncBaseTransport):
             logger.warning("Blocked SSRF request (url validation): %s", request.url)
             raise
 
+        # Ensure the request body is buffered before forwarding or rebuilding
+        # the request, because redirect hops arrive in streaming state.
+        await request.aread()
+
         # Allowed-hosts bypass - skip DNS/IP validation entirely.
         if hostname.lower() in {h.lower() for h in self._policy.allowed_hosts}:
             return await self._inner.handle_async_request(request)

--- a/backend/tests/integration/test_api_tokens.py
+++ b/backend/tests/integration/test_api_tokens.py
@@ -174,7 +174,9 @@ class TestAPITokenRevoke:
     @pytest.mark.asyncio
     async def test_revoke_nonexistent_token(self, client: AsyncClient, auth_headers):
         """Test revoking a non-existent token."""
-        response = await client.delete("/api/tokens/nonexistent-id", headers=auth_headers)
+        response = await client.delete(
+            "/api/tokens/00000000-0000-0000-0000-000000000000", headers=auth_headers
+        )
 
         assert response.status_code == 404
 


### PR DESCRIPTION
Call aread() before forwarding or rebuilding the request to prevent httpx.RequestNotRead when redirect hops arrive in streaming state.